### PR TITLE
Remove an admin mutation from the oplog resource

### DIFF
--- a/docs/resources/oplog.md
+++ b/docs/resources/oplog.md
@@ -18,10 +18,9 @@ data "ghostwriter_project" "testproject" {
 }
 
 resource "ghostwriter_oplog" "test" {
-  name               = "Test Oplog"
-  project_id         = data.ghostwriter_project.testproject.id
-  mute_notifications = true
-  force_delete       = true
+  name         = "Test Oplog"
+  project_id   = data.ghostwriter_project.testproject.id
+  force_delete = true
 }
 ```
 
@@ -36,7 +35,6 @@ resource "ghostwriter_oplog" "test" {
 ### Optional
 
 - `force_delete` (Boolean) If false, will not be deleted from the ghostwriter instance when not managed by terraform. If true, the oplog will be hard-deleted from the ghostwriter instance. Default is false.
-- `mute_notifications` (Boolean) Notification status determines if Ghostwriter will send notifications for the log when the "Review Active Logs" task is run.
 
 ### Read-Only
 

--- a/examples/resources/ghostwriter_oplog/resource.tf
+++ b/examples/resources/ghostwriter_oplog/resource.tf
@@ -3,8 +3,7 @@ data "ghostwriter_project" "testproject" {
 }
 
 resource "ghostwriter_oplog" "test" {
-  name               = "Test Oplog"
-  project_id         = data.ghostwriter_project.testproject.id
-  mute_notifications = true
-  force_delete       = true
+  name         = "Test Oplog"
+  project_id   = data.ghostwriter_project.testproject.id
+  force_delete = true
 }

--- a/internal/provider/oplog_resource_test.go
+++ b/internal/provider/oplog_resource_test.go
@@ -26,7 +26,6 @@ resource "ghostwriter_oplog" "test" {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ghostwriter_oplog.test", "name", "Test Oplog"),
 					resource.TestCheckResourceAttr("ghostwriter_oplog.test", "project_id", "1"),
-					resource.TestCheckResourceAttr("ghostwriter_oplog.test", "mute_notifications", "false"),
 					resource.TestCheckResourceAttr("ghostwriter_oplog.test", "force_delete", "true"),
 					resource.TestCheckResourceAttrSet("ghostwriter_oplog.test", "id"),
 					resource.TestCheckResourceAttrSet("ghostwriter_oplog.test", "last_updated"),
@@ -51,14 +50,12 @@ data "ghostwriter_project" "testproject" {
 resource "ghostwriter_oplog" "test" {
   name = "Test Updated Oplog"
   project_id = data.ghostwriter_project.testproject.id
-  mute_notifications = true
   force_delete = true
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ghostwriter_oplog.test", "name", "Test Updated Oplog"),
 					resource.TestCheckResourceAttr("ghostwriter_oplog.test", "project_id", "1"),
-					resource.TestCheckResourceAttr("ghostwriter_oplog.test", "mute_notifications", "true"),
 					resource.TestCheckResourceAttr("ghostwriter_oplog.test", "force_delete", "true"),
 					resource.TestCheckResourceAttrSet("ghostwriter_oplog.test", "id"),
 					resource.TestCheckResourceAttrSet("ghostwriter_oplog.test", "last_updated"),


### PR DESCRIPTION
When using the oplog resource with a API key that has either `manager` or `user` permissions you will get this error `"operation":{"error":{"code":"validation-failed","error":"field 'mute_notifications' not found in type: 'oplog_insert_input'","path":"$.selectionSet.insert_oplog.args.objects[0].mute_notifications"}`

This PR removes those admin mutations so the oplog resource works with those roles